### PR TITLE
refactor: button components stories and examples

### DIFF
--- a/packages/components/src/components/button/button.stories.ts
+++ b/packages/components/src/components/button/button.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj, Args } from '@storybook/web-components';
 import '.';
 import { html } from 'lit';
-import { BUTTON_COLORS, ICON_BUTTON_SIZES, BUTTON_VARIANTS } from './button.constants';
+import { BUTTON_COLORS, PILL_BUTTON_SIZES, BUTTON_VARIANTS, ICON_BUTTON_SIZES } from './button.constants';
 import { classArgType, styleArgType } from '../../../config/storybook/commonArgTypes';
 
 const render = (args: Args) => html`
@@ -49,7 +49,7 @@ const meta: Meta = {
     size: {
       description: 'The size of the button.',
       control: 'select',
-      options: Object.values(ICON_BUTTON_SIZES),
+      options: Object.values(PILL_BUTTON_SIZES),
     },
     color: {
       description: 'The color of the button.',
@@ -70,7 +70,7 @@ export const Primary: StoryObj = {
     disabled: false,
     'soft-disabled': false,
     variant: BUTTON_VARIANTS.PRIMARY,
-    size: ICON_BUTTON_SIZES[32],
+    size: PILL_BUTTON_SIZES[32],
     color: BUTTON_COLORS.DEFAULT,
   },
 };
@@ -83,7 +83,7 @@ export const PrefixIcon: StoryObj = {
     disabled: false,
     'soft-disabled': false,
     variant: BUTTON_VARIANTS.PRIMARY,
-    size: ICON_BUTTON_SIZES[32],
+    size: PILL_BUTTON_SIZES[32],
     color: BUTTON_COLORS.DEFAULT,
   },
 };
@@ -96,12 +96,17 @@ export const PostfixIcon: StoryObj = {
     disabled: false,
     'soft-disabled': false,
     variant: BUTTON_VARIANTS.PRIMARY,
-    size: ICON_BUTTON_SIZES[32],
+    size: PILL_BUTTON_SIZES[32],
     color: BUTTON_COLORS.DEFAULT,
   },
 };
 
 export const Icon: StoryObj = {
+  argTypes: {
+    size: {
+      options: Object.values(ICON_BUTTON_SIZES),
+    },
+  },
   args: {
     children: html`<mdc-icon name="info-circle-bold"></mdc-icon>`,
     active: false,
@@ -120,7 +125,7 @@ export const Text: StoryObj = {
     disabled: false,
     'soft-disabled': false,
     variant: BUTTON_VARIANTS.PRIMARY,
-    size: ICON_BUTTON_SIZES[32],
+    size: PILL_BUTTON_SIZES[32],
     color: BUTTON_COLORS.DEFAULT,
   },
 };

--- a/packages/components/src/components/button/button.stories.ts
+++ b/packages/components/src/components/button/button.stories.ts
@@ -63,7 +63,7 @@ const meta: Meta = {
 
 export default meta;
 
-export const Primary: StoryObj = {
+export const PillButton: StoryObj = {
   args: {
     children: 'Click Me',
     active: false,
@@ -75,10 +75,10 @@ export const Primary: StoryObj = {
   },
 };
 
-export const PrefixIcon: StoryObj = {
+export const PillWithPrefixIcon: StoryObj = {
   args: {
     children: html`<mdc-icon name="info-circle-bold" slot="prefix-icon"></mdc-icon>
-      <span>Left Icon</span>`,
+    Left Icon`,
     active: false,
     disabled: false,
     'soft-disabled': false,
@@ -88,9 +88,9 @@ export const PrefixIcon: StoryObj = {
   },
 };
 
-export const PostfixIcon: StoryObj = {
+export const PillWithPostfixIcon: StoryObj = {
   args: {
-    children: html`<p>Right Icon</p>
+    children: html`Right Icon
       <mdc-icon name="info-circle-bold" slot="postfix-icon"></mdc-icon>`,
     active: false,
     disabled: false,
@@ -101,7 +101,7 @@ export const PostfixIcon: StoryObj = {
   },
 };
 
-export const Icon: StoryObj = {
+export const IconButton: StoryObj = {
   argTypes: {
     size: {
       options: Object.values(ICON_BUTTON_SIZES),
@@ -114,18 +114,6 @@ export const Icon: StoryObj = {
     'soft-disabled': false,
     variant: BUTTON_VARIANTS.PRIMARY,
     size: ICON_BUTTON_SIZES[32],
-    color: BUTTON_COLORS.DEFAULT,
-  },
-};
-
-export const Text: StoryObj = {
-  args: {
-    children: html`<span>Label</span>`,
-    active: false,
-    disabled: false,
-    'soft-disabled': false,
-    variant: BUTTON_VARIANTS.PRIMARY,
-    size: PILL_BUTTON_SIZES[32],
     color: BUTTON_COLORS.DEFAULT,
   },
 };

--- a/packages/components/src/components/button/button.stories.ts
+++ b/packages/components/src/components/button/button.stories.ts
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj, Args } from '@storybook/web-components';
 import '.';
 import { html } from 'lit';
-import { classArgType, styleArgType } from '../../../config/storybook/commonArgTypes';
 import { BUTTON_COLORS, ICON_BUTTON_SIZES, BUTTON_VARIANTS } from './button.constants';
+import { classArgType, styleArgType } from '../../../config/storybook/commonArgTypes';
 
 const render = (args: Args) => html`
   <mdc-button 
@@ -60,11 +60,62 @@ const meta: Meta = {
     ...styleArgType,
   },
 };
+
 export default meta;
 
 export const Primary: StoryObj = {
   args: {
     children: 'Click Me',
+    active: false,
+    disabled: false,
+    'soft-disabled': false,
+    variant: BUTTON_VARIANTS.PRIMARY,
+    size: ICON_BUTTON_SIZES[32],
+    color: BUTTON_COLORS.DEFAULT,
+  },
+};
+
+export const PrefixIcon: StoryObj = {
+  args: {
+    children: html`<mdc-icon name="info-circle-bold" slot="prefix-icon"></mdc-icon>
+      <span>Left Icon</span>`,
+    active: false,
+    disabled: false,
+    'soft-disabled': false,
+    variant: BUTTON_VARIANTS.PRIMARY,
+    size: ICON_BUTTON_SIZES[32],
+    color: BUTTON_COLORS.DEFAULT,
+  },
+};
+
+export const PostfixIcon: StoryObj = {
+  args: {
+    children: html`<p>Right Icon</p>
+      <mdc-icon name="info-circle-bold" slot="postfix-icon"></mdc-icon>`,
+    active: false,
+    disabled: false,
+    'soft-disabled': false,
+    variant: BUTTON_VARIANTS.PRIMARY,
+    size: ICON_BUTTON_SIZES[32],
+    color: BUTTON_COLORS.DEFAULT,
+  },
+};
+
+export const Icon: StoryObj = {
+  args: {
+    children: html`<mdc-icon name="info-circle-bold"></mdc-icon>`,
+    active: false,
+    disabled: false,
+    'soft-disabled': false,
+    variant: BUTTON_VARIANTS.PRIMARY,
+    size: ICON_BUTTON_SIZES[32],
+    color: BUTTON_COLORS.DEFAULT,
+  },
+};
+
+export const Text: StoryObj = {
+  args: {
+    children: html`<span>Label</span>`,
     active: false,
     disabled: false,
     'soft-disabled': false,


### PR DESCRIPTION
<!--────────────────────────────────────────
Checklist before submitting a Pull Request, please ensure you've done the following:
- ✅ Set the "validated" label on this Pull Request if you have the permissions to do so.

- 📝 Write a proper PR title and fill out the description below

- 📖 Read the Contributing guide: 
https://github.com/momentum-design/momentum-design/blob/main/CONTRIBUTING.md

- 🏗️ When making changes to components, follow these conventions: 
https://github.com/momentum-design/momentum-design/tree/main/packages/components/conventions

NOTE: Pull Requests from forked repositories will need to be "validated" by a Momentum Team member before any CI builds will run. Once your PR is "validated", it will be allowed to run subsequent builds without manual approval.
────────────────────────────────────────-->

# Description
- Button component has 3 types:
  -  Pill button - Button that contains text value. It is commonly used for call to action, tags or filters.
  - Pill button with icons - Button containing icon either on the left or right side of the button. 
  - Icon button - Button is represented by just an icon without any text. 
- They have 3 variants - Primary, Secondary and Tertiary. 
- Different states a button can have are as follows: Active, Disabled, SoftDisabled (The button is currently disabled for user interaction; however, it remains focusable.)
- Colors:
  - Positive - Green button 
  - Negative - Red button 
  - Accent - Blue button 
  - Promotional - Purple button 
  - Default - Grey button 

We support the following sizes which vary based on the button type. As per our conventions guide, we shall use REM unit for button sizing.
- Pill button - 40, 32, 28, 24. 
- Icon button - 64, 52, 40, 32, 28 and 24.
    - Tertiary icon button can be of 20.
 
## Links
- [Storybook ticket](https://jira-eng-gpk2.cisco.com/jira/browse/MOMENTUM-387)

## Screenshots

### Pill Button
![image](https://github.com/user-attachments/assets/cc177500-2c32-425d-bec0-8b82f3499e06)

### Pill with Icon Button (prefix slot)
![image](https://github.com/user-attachments/assets/8ac5dd00-c0e2-4ddb-a772-17cb6bdabe1c)

### Pill with Icon Button (postfix slot)
![image](https://github.com/user-attachments/assets/50d6c73d-64bc-4271-8561-82023465d1a6)

### Icon Button (soft disabled)
![image](https://github.com/user-attachments/assets/d3b56440-d4f2-4fd8-a763-32c852991760)

### Active disabled button
![image](https://github.com/user-attachments/assets/d7c1708e-66ae-4dc6-989b-9d7cc1e5932f)
