### PR TITLE
chore: add hide control for button storybook

### DIFF
--- a/packages/components/config/storybook/utils.ts
+++ b/packages/components/config/storybook/utils.ts
@@ -13,4 +13,21 @@ const disableControls = (keys: Array<string>) => {
   return objectReturnValue;
 };
 
-export { disableControls };
+/**
+ * To automatically hide controls in storybook
+ * @param keys - Array of keys to hide
+ * @returns Object which can be destructured in argTypes
+ */
+const hideControls = (keys: Array<string>) => {
+  const objectReturnValue: Record<string, any> = {};
+  keys.forEach((key) => {
+    objectReturnValue[key] = {
+      table: {
+        disable: true,
+      },
+    };
+  });
+  return objectReturnValue;
+};
+
+export { disableControls, hideControls };

--- a/packages/components/src/components/button/button.stories.ts
+++ b/packages/components/src/components/button/button.stories.ts
@@ -3,6 +3,7 @@ import '.';
 import { html } from 'lit';
 import { BUTTON_COLORS, PILL_BUTTON_SIZES, BUTTON_VARIANTS, ICON_BUTTON_SIZES } from './button.constants';
 import { classArgType, styleArgType } from '../../../config/storybook/commonArgTypes';
+import { hideControls } from '../../../config/storybook/utils';
 
 const render = (args: Args) => html`
   <mdc-button 
@@ -56,6 +57,13 @@ const meta: Meta = {
       control: 'select',
       options: Object.values(BUTTON_COLORS),
     },
+    ...hideControls([
+      'iconSize',
+      'buttonType',
+      'form',
+      'internals',
+      'default',
+    ]),
     ...classArgType,
     ...styleArgType,
   },


### PR DESCRIPTION

# Description

- From now, we can hide any control we wish to in storybook.
- This PR will add a utility method to hide attributes in storybook.

### Before
![image](https://github.com/user-attachments/assets/58210ed7-d161-4bbc-9fea-f077e9776944)

### After
![image](https://github.com/user-attachments/assets/c3ce4bdc-4b15-4878-a1de-35599b9ead16)
